### PR TITLE
ensure postgres/redis containers uses port defined in .env file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
-DC = docker exec -it opendorme_app_1 /bin/bash -c
+DC = docker exec -it opendorme_app /bin/bash -c
 
 connect-app: ## Connect to app container
-	docker exec -it opendorme_app_1 /bin/bash
+	docker exec -it opendorme_app /bin/bash
 
 build: ## Build local environment
 	mkdir -p ./storage/nginx

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ version: "3.9"
 
 services:
   app:
+    container_name: opendorme_app
     build:
       args:
         user: opendor-dev
@@ -19,6 +20,7 @@ services:
       - opendor
 
   db:
+    container_name: opendorme_db
     image: postgres:13
     restart: unless-stopped
     environment:
@@ -33,6 +35,7 @@ services:
       - opendor
 
   nginx:
+    container_name: opendorme_nginx
     build:
       context: ./
       dockerfile: .docker/nginx/Dockerfile
@@ -47,6 +50,7 @@ services:
       - opendor
 
   redis:
+    container_name: opendorme_redis
     image: "redis:alpine"
     ports:
       - "${REDIS_PORT:-6379}:6379"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,13 +24,16 @@ services:
     image: postgres:13
     restart: unless-stopped
     environment:
+      PGPORT: ${DB_PORT:-5432}
       POSTGRES_DB: ${DB_DATABASE}
       POSTGRES_USER: ${DB_USERNAME}
       POSTGRES_PASSWORD: ${DB_PASSWORD}
     volumes:
       - psql:/var/lib/postgresql/data
+    expose:
+      - "${DB_PORT:-5432}"
     ports:
-      - "${DB_PORT:-5432}:5432"
+      - "${DB_PORT:-5432}:${DB_PORT:-5432}"
     networks:
       - opendor
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,8 +30,6 @@ services:
       POSTGRES_PASSWORD: ${DB_PASSWORD}
     volumes:
       - psql:/var/lib/postgresql/data
-    expose:
-      - "${DB_PORT:-5432}"
     ports:
       - "${DB_PORT:-5432}:${DB_PORT:-5432}"
     networks:
@@ -56,8 +54,6 @@ services:
     container_name: opendorme_redis
     image: "redis:alpine"
     command: "--port ${REDIS_PORT:-6379}"
-    expose:
-      - "${REDIS_PORT:-6379}"
     ports:
       - "${REDIS_PORT:-6379}:${REDIS_PORT:-6379}"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,8 +55,11 @@ services:
   redis:
     container_name: opendorme_redis
     image: "redis:alpine"
+    command: "--port ${REDIS_PORT:-6379}"
+    expose:
+      - "${REDIS_PORT:-6379}"
     ports:
-      - "${REDIS_PORT:-6379}:6379"
+      - "${REDIS_PORT:-6379}:${REDIS_PORT:-6379}"
     volumes:
       - "redis:/data"
     networks:


### PR DESCRIPTION
Prevents the need for additional Env files or Docker specific env vars.